### PR TITLE
Update TAK CLI Cask to v11.12.0

### DIFF
--- a/Casks/t/tak-cli.rb
+++ b/Casks/t/tak-cli.rb
@@ -1,6 +1,6 @@
 cask "tak-cli" do
-  version "11.3.0"
-  sha256 "4fb3841cc464f3a4ff5043a583d59661f4731febcbeca9f88b1084a8a115533a"
+  version "11.12.0"
+  sha256 "c819877c5f0ea456ba6a573e3dcbbe22f863ff0d1f5cf6e054b1bf17f7c9ede1"
 
   url "https://github.com/microsoft/xbox-game-streaming-tools/releases/download/tak-cli-v#{version}/tak-#{version}.dmg"
   name "Touch Adaptation Kit Command Line Tool (TAK CLI)"


### PR DESCRIPTION
This automated PR updates the TAK CLI cask for version 11.12.0. Please review and merge.