### PR TITLE
Update TAK CLI Cask to v11.25.0

### DIFF
--- a/Casks/t/tak-cli.rb
+++ b/Casks/t/tak-cli.rb
@@ -1,23 +1,25 @@
 cask "tak-cli" do
-  version "11.18.0"
-  sha256 "117199b54e745c3d13d8bc82f5a88b4cf57b8f64bde3a14b82bae47189c5ef9e"
+    version "11.25.0"
+    sha256 arm:   "f2f8fdfeaeca58b29e26b62f8c975d02e7fd7d269b20b4591cccaa2efcfba306",
+           intel: "b88c487c33f0a6a4e3f07cdd0b9a44a4f6a3074f5eaea18d05639de5342eba7f"
+    arch arm: "arm64", intel: "x64"
 
-  url "https://github.com/microsoft/xbox-game-streaming-tools/releases/download/tak-cli-v#{version}/tak-#{version}.dmg"
-  name "Touch Adaptation Kit Command Line Tool (TAK CLI)"
-  desc "Command-line tool for creating and managing touch adaptation bundles for Xbox"
-  homepage "https://github.com/microsoft/xbox-game-streaming-tools"
+    url "https://github.com/microsoft/xbox-game-streaming-tools/releases/download/tak-cli-v#{version}/tak-#{version}-#{arch}.dmg"
+    name "Touch Adaptation Kit Command Line Tool (TAK CLI)"
+    desc "Command-line tool for creating and managing touch adaptation bundles for Xbox"
+    homepage "https://github.com/microsoft/xbox-game-streaming-tools"
 
-  livecheck do
-    regex(/tak-cli-v(\d+(?:\.\d+)+)/i) # tags like `tak-cli-v11.0.0`
-  end
+    livecheck do
+        regex(/tak-cli-v(\d+(?:\.\d+)+)/i) # tags like `tak-cli-v11.0.0`
+    end
 
-  binary "tak"
+    binary "tak"
 
-  postflight do
-    system_command "/bin/chmod", args: ["+x", "#{staged_path}/tak"]
-  end
+    postflight do
+        system_command "/bin/chmod", args: ["+x", "#{staged_path}/tak"]
+    end
 
-  uninstall delete: "#{HOMEBREW_PREFIX}/bin/tak"
+    uninstall delete: "#{HOMEBREW_PREFIX}/bin/tak"
 
-  zap trash: "~/Library/Application Support/Microsoft/Xbox Creator Tools/TAK CLI"
+    zap trash: "~/Library/Application Support/Microsoft/Xbox Creator Tools/TAK CLI"
 end

--- a/Casks/t/tak-cli.rb
+++ b/Casks/t/tak-cli.rb
@@ -2,7 +2,7 @@ cask "tak-cli" do
     version "11.25.0"
     sha256 arm:   "f2f8fdfeaeca58b29e26b62f8c975d02e7fd7d269b20b4591cccaa2efcfba306",
            intel: "b88c487c33f0a6a4e3f07cdd0b9a44a4f6a3074f5eaea18d05639de5342eba7f"
-    arch arm: "arm64", intel: "x64"
+    arch arm: "osx-arm64", intel: "osx-x64"
 
     url "https://github.com/microsoft/xbox-game-streaming-tools/releases/download/tak-cli-v#{version}/tak-#{version}-#{arch}.dmg"
     name "Touch Adaptation Kit Command Line Tool (TAK CLI)"


### PR DESCRIPTION
This automated PR updates the TAK CLI cask for version 11.25.0. Please review and merge.